### PR TITLE
Allow gzip responses from MailChimp through DecompressingHttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@ limitations under the License.
 			<version>4.2.5</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.2.4</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>16.0.1</version>

--- a/src/main/java/com/ecwid/mailchimp/connection/HttpClientConnectionManager.java
+++ b/src/main/java/com/ecwid/mailchimp/connection/HttpClientConnectionManager.java
@@ -20,7 +20,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.DecompressingHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.util.EntityUtils;
@@ -35,7 +35,7 @@ public class HttpClientConnectionManager implements MailChimpConnectionManager {
 
 	private static final int DEFAULT_TIMEOUT = 15000;
 
-	private final HttpClient http = new DefaultHttpClient();
+	private final HttpClient http = new DecompressingHttpClient(new DefaultHttpClient());
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
I've started to get gzipped responses from MailChimp in certain error cases, but the Apache HttpClient doesn't decompress the response before calling `EntityUtils.toString`. This resulted in a garbage string that later caused JSON parsing errors:
```
Caused by: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 2
	at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1505) ~[LeadinJobs-executable.jar:na]
	at com.google.gson.stream.JsonReader.checkLenient(JsonReader.java:1386) ~[LeadinJobs-executable.jar:na]
	at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:531) ~[LeadinJobs-executable.jar:na]
	at com.google.gson.stream.JsonReader.peek(JsonReader.java:414) ~[LeadinJobs-executable.jar:na]
	at com.google.gson.JsonParser.parse(JsonParser.java:60) ~[LeadinJobs-executable.jar:na]
	... 16 common frames omitted
```

This change ensures that GZipped responses are properly decompressed before reading the response content. I've verified this change no longer causes the above exception.

@basiliscus